### PR TITLE
Fix boolean conversion bug

### DIFF
--- a/persistent-mysql-haskell/ChangeLog.md
+++ b/persistent-mysql-haskell/ChangeLog.md
@@ -1,3 +1,6 @@
+## 0.4.2
+- [#7](https://github.com/naushadh/persistent/pull/7) Fix boolean conversion bug.
+
 ## 0.4.1
 
 - Fix [#2](https://github.com/naushadh/persistent/issues/2): Better compatibility with `yesod` scaffold.

--- a/persistent-mysql-haskell/Database/Persist/MySQL.hs
+++ b/persistent-mysql-haskell/Database/Persist/MySQL.hs
@@ -251,11 +251,6 @@ encodeBool :: Bool -> MySQL.MySQLValue
 encodeBool True = MySQL.MySQLInt8U 1
 encodeBool False = MySQL.MySQLInt8U 0
 
--- | Decode a Numeric value into a PersistBool
-decodeBool :: (Eq a, Num a) => a -> PersistValue
-decodeBool 0 = PersistBool False
-decodeBool _ = PersistBool True
-
 -- | Decode a whole number into a PersistInt64
 decodeInteger :: Integral a => a -> PersistValue
 decodeInteger = PersistInt64 . fromIntegral

--- a/persistent-mysql-haskell/Database/Persist/MySQL.hs
+++ b/persistent-mysql-haskell/Database/Persist/MySQL.hs
@@ -294,14 +294,8 @@ type Getter a = MySQL.MySQLValue -> a
 -- | Get the corresponding @'Getter' 'PersistValue'@ depending on
 -- the type of the column.
 getGetter :: MySQL.ColumnDef -> Getter PersistValue
-getGetter field = case (MySQL.columnLength field) of
-  1 -> goBool
-  _ -> go
+getGetter _field = go
   where
-    -- Bool
-    goBool (MySQL.MySQLInt8U v) = decodeBool v
-    goBool (MySQL.MySQLInt8  v) = decodeBool v
-    goBool _                    = PersistBool False
     -- Int64
     go (MySQL.MySQLInt8U  v) = decodeInteger v
     go (MySQL.MySQLInt8   v) = decodeInteger v

--- a/persistent-mysql-haskell/persistent-mysql-haskell.cabal
+++ b/persistent-mysql-haskell/persistent-mysql-haskell.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql-haskell
-version:         0.4.1
+version:         0.4.2
 license:         MIT
 license-file:    LICENSE
 author:          Naushadh <naushadh@protonmail.com>, Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman


### PR DESCRIPTION
Defaulting to `False` for many column types is very wrong. From a MySQL type we never know for sure that something is a boolean, so we can just return the integer, and let persistent convert it to a boolean. With the old version, if you (with MariaDB at least) select TRUE, you get `False` in Haskell because the column has size 1 but is apparently not `Int8` or `Int8U`.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
