### PR TITLE
Add insertEntityOnDuplicateKeyUpdate and insertEntityManyOnDuplicateKeyUpdate functions

### DIFF
--- a/persistent-mysql-haskell/ChangeLog.md
+++ b/persistent-mysql-haskell/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.5.1
 
-- [#8](https://github.com/naushadh/persistent/pull/8) Add `insertEntityOnDuplicateKeyUpdate` and `insertEntityManyOnDuplicateKeyUpdate` functions
+- [#9](https://github.com/naushadh/persistent/pull/9) Add `insertEntityOnDuplicateKeyUpdate` and `insertEntityManyOnDuplicateKeyUpdate` functions
 
 
 ## 0.5.0

--- a/persistent-mysql-haskell/ChangeLog.md
+++ b/persistent-mysql-haskell/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for `persistent-mysql-haskell`
 
+## 0.5.1
+
+- [#8](https://github.com/naushadh/persistent/pull/8) Add `insertEntityOnDuplicateKeyUpdate` and `insertEntityManyOnDuplicateKeyUpdate` functions
+
+
 ## 0.5.0
 
 - Port [#812](https://github.com/yesodweb/persistent/pull/812) from `persistent-mysql`: Add support for SQL isolation levels

--- a/persistent-mysql-haskell/Database/Persist/MySQL.hs
+++ b/persistent-mysql-haskell/Database/Persist/MySQL.hs
@@ -1134,6 +1134,7 @@ insertOnDuplicateKeyUpdate record =
   insertManyOnDuplicateKeyUpdate [record] []
 
 -- | Combination of 'insertOnDuplicateKeyUpdate' and 'insertKey'.
+--   @since 5.1.0
 insertEntityOnDuplicateKeyUpdate
   :: ( backend ~ PersistEntityBackend record
      , PersistEntity record
@@ -1312,6 +1313,7 @@ insertManyOnDuplicateKeyUpdate records fieldValues updates =
     $ mkBulkInsertQuery (Left records) fieldValues updates
 
 -- | Combination of 'insertManyOnDuplicateKeyUpdate' and 'insertEntityMany'
+--   @since 5.1.0
 insertEntityManyOnDuplicateKeyUpdate
     :: forall record backend m.
     ( backend ~ PersistEntityBackend record

--- a/persistent-mysql-haskell/persistent-mysql-haskell.cabal
+++ b/persistent-mysql-haskell/persistent-mysql-haskell.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql-haskell
-version:         0.5.0
+version:         0.5.1
 license:         MIT
 license-file:    LICENSE
 author:          Naushadh <naushadh@protonmail.com>, Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

The title should say it all, I'd like to insert something where I have the key of the entity as well, and also want to add an `ON DUPLICATE KEY UPDATE` part. This simply adds two new functions for that, and should be 100% backwards compatible.