### PR TITLE
Build with GHC 8.8

### DIFF
--- a/persistent-mysql-haskell/persistent-mysql-haskell.cabal
+++ b/persistent-mysql-haskell/persistent-mysql-haskell.cabal
@@ -43,7 +43,7 @@ library
                    , io-streams            >= 1.2     && < 2.0
                    , time                  >= 1.5.0
                    , network               >= 2.3     && < 4.0
-                   , tls                   >= 1.3.5   && < 1.5
+                   , tls                   >= 1.3.5
     exposed-modules: Database.Persist.MySQL
     other-modules:   Database.Persist.MySQLConnectInfoShowInstance
     ghc-options:     -Wall


### PR DESCRIPTION
This removes the `tls` upper bound, since versions of `tls < 1.5` (e.g. `1.4.1`, and maybe later versions too?) don't build with GHC 8.8 due to a missing `MonadFail` constraint.

```
tls                              > /tmp/stack-5280da6a145234f9/tls-1.4.1/Network/TLS/Packet.hs:648:27: error:
tls                              >     • Could not deduce (MonadFail m) arising from a use of ‘fail’
tls                              >       from the context: Monad m
tls                              >         bound by the type signature for:
tls                              >                    fromJustM :: forall (m :: * -> *) a.
tls                              >                                 Monad m =>
tls                              >                                 String -> Maybe a -> m a
tls                              >         at Network/TLS/Packet.hs:647:1-48
tls                              >       Possible fix:
tls                              >         add (MonadFail m) to the context of
tls                              >           the type signature for:
tls                              >             fromJustM :: forall (m :: * -> *) a.
tls                              >                          Monad m =>
tls                              >                          String -> Maybe a -> m a
tls                              >     • In the expression: fail ("fromJust " ++ what ++ ": Nothing")
tls                              >       In an equation for ‘fromJustM’:
tls                              >           fromJustM what Nothing = fail ("fromJust " ++ what ++ ": Nothing")
tls                              >     |
tls                              > 648 | fromJustM what Nothing  = fail ("fromJust " ++ what ++ ": Nothing")
tls                              >     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tls                              >
```