### PR TITLE
Loosened backend constraints

### DIFF
--- a/persistent-mysql-haskell/ChangeLog.md
+++ b/persistent-mysql-haskell/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for `persistent-mysql-haskell`
 
+## 0.6.1
+
+- [#14](https://github.com/naushadh/persistent/pull/14) Loosened constraints around `SqlBackend`
+
 ## 0.6.0
 
 - Port [#977](https://github.com/yesodweb/persistent/pull/977) from `persistent-mysql`: Support Stackage Nightly

--- a/persistent-mysql-haskell/persistent-mysql-haskell.cabal
+++ b/persistent-mysql-haskell/persistent-mysql-haskell.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql-haskell
-version:         0.6.0
+version:         0.6.1
 license:         MIT
 license-file:    LICENSE
 author:          Naushadh <naushadh@protonmail.com>, Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

This PR changes the creation of `SqlBackend`s to some type `backend` for which the constraints `IsPersistBackend backend, BaseBackend backend ~ SqlBackend, BackendCompatible SqlBackend backend` hold. This allows the user to use this package with other backends than just `SqlBackend`. My own use case for this is to be able to use `SqlReadBackend`. This way, I can run read-only queries on a different connection than writing queries.